### PR TITLE
Remove constexpr for old versions of Visual C++ (before VS2015)

### DIFF
--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -23,6 +23,16 @@
 #include <cfloat>
 #include <cstring>
 
+#ifdef _MSC_VER
+#	if _MSC_VER < 1900
+	// Before Visual Studio 2015, Visual C++ did not yet support constexpr
+#	define BIOVAULT_BFLOAT16_CONSTEXPR
+#	endif
+#endif
+
+#ifndef BIOVAULT_BFLOAT16_CONSTEXPR
+#define BIOVAULT_BFLOAT16_CONSTEXPR constexpr
+#endif
 
 namespace biovault {
 
@@ -34,7 +44,7 @@ namespace biovault {
 	public:
 		bfloat16_t() = default;
 
-		constexpr bfloat16_t(const std::uint16_t r, bool) : raw_bits_(r) {}
+		BIOVAULT_BFLOAT16_CONSTEXPR bfloat16_t(const std::uint16_t r, bool) : raw_bits_(r) {}
 
 		// Supports narrowing (lossy) conversion from 32-bit float to bfloat16.
 		explicit bfloat16_t(const float f) {

--- a/biovault_bfloat16_test.cpp
+++ b/biovault_bfloat16_test.cpp
@@ -261,6 +261,14 @@ GTEST_TEST(bfloat16, Epsilon)
 }
 
 
+GTEST_TEST(bfloat16, AllowsConstexprConstructionFromRawBits)
+{
+	BIOVAULT_BFLOAT16_CONSTEXPR biovault::bfloat16_t bfloat16_from_raw_bits(std::uint16_t{}, bool{});
+	const float f = bfloat16_from_raw_bits;
+	EXPECT_EQ(f, 0.0f);
+}
+
+
 GTEST_TEST(bfloat16, RawRoundTrip)
 {
 	constexpr std::uint16_t _15{ std::numeric_limits<std::uint16_t>::digits - 1 };


### PR DESCRIPTION
Requested by Jeroen Eggermont, as he would like to use `biovault::bfloat16_t` in a VS2013 application.

Also added a test, to allow constexpr construction of a bfloat16 from raw bits.