### PR TITLE
Fix bfloat16.Epsilon unit test, address issue #3 (mixup with epsilon), code cleanup 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 project(biovault_bfloat16)
 
-cmake_minimum_required( VERSION 3.11.4 )
+# At the moment of writing (July 2020), the Microsoft-hosted VM ubuntu-18.04
+# still runs CMake 3.17.0 on Azure Pipelines.
+cmake_minimum_required( VERSION 3.17.0 )
 
 message(STATUS "[${PROJECT_NAME}] CMAKE_VERSION = ${CMAKE_VERSION}")
 message(STATUS "[${PROJECT_NAME}] CMAKE_GENERATOR = ${CMAKE_GENERATOR}")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: VS2019
+- job: Windows_VS2019
   pool:
     vmImage: 'windows-2019'
   steps:
@@ -10,10 +10,10 @@ jobs:
       cmake .. -G "Visual Studio 16 2019" -A x64
       MSBuild.exe ..\build\biovault_bfloat16.sln /property:Configuration=Release
       cd ..
-    displayName: VS2019 Build!
+    displayName: $(Agent.JobName) Visual C++ build
   - script: |
       .\build\Release\biovault_bfloat16_test.exe
-    displayName: Run it!
+    displayName: $(Agent.JobName) run
 
 - job: Ubuntu1804_GCC_7_4_0
   pool:
@@ -25,12 +25,12 @@ jobs:
       cmake ..
       make
       cd ..
-    displayName: GCC build
+    displayName: $(Agent.JobName) GCC build
   - script: |
       ./build/biovault_bfloat16_test
-    displayName: GCC run
+    displayName: $(Agent.JobName) run
    
-- job: macOS1014_AppleClang_11_0_0_11000033
+- job: macOS1014_AppleClang
   pool:
     vmImage: 'macOS-10.14'
   steps:
@@ -40,8 +40,8 @@ jobs:
       cmake ..
       make
       cd ..
-    displayName: Clang build macOS-10.14
+    displayName: $(Agent.JobName) Clang build
   - script: |
       ./build/biovault_bfloat16_test
-    displayName: Run!
+    displayName: $(Agent.JobName) run
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,9 @@ jobs:
       ./build/biovault_bfloat16_test
     displayName: $(Agent.JobName) run
    
-- job: macOS1014_AppleClang
+- job: macOS1015_AppleClang
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - script: |
       mkdir build

--- a/biovault_bfloat16_test.cpp
+++ b/biovault_bfloat16_test.cpp
@@ -215,8 +215,8 @@ GTEST_TEST(bfloat16, PowerOfTwoRoundTripIsLossless)
 
 GTEST_TEST(bfloat16, MaxBFloat16RoundTripIsLossless)
 {
-	const auto max_bfloat16 = 3.38953139e38f;
-	const auto max_float32 = 3.402823466e38f;
+	constexpr auto max_bfloat16 = 3.38953139e38f;
+	constexpr auto max_float32 = 3.402823466e38f;
 
 	ASSERT_EQ(max_float32, float_limits::max());
 	ASSERT_LT(max_bfloat16, float_limits::max());
@@ -328,7 +328,7 @@ GTEST_TEST(bfloat16, Epsilon)
 
 GTEST_TEST(bfloat16, AllowsConstexprConstructionFromRawBits)
 {
-	BIOVAULT_BFLOAT16_CONSTEXPR biovault::bfloat16_t bfloat16_from_raw_bits(std::uint16_t{}, bool{});
+	constexpr biovault::bfloat16_t bfloat16_from_raw_bits(std::uint16_t{}, bool{});
 	const float f = bfloat16_from_raw_bits;
 	EXPECT_EQ(f, 0.0f);
 }
@@ -336,13 +336,13 @@ GTEST_TEST(bfloat16, AllowsConstexprConstructionFromRawBits)
 
 GTEST_TEST(bfloat16, RawBitsRoundTripIsLossless)
 {
-	BIOVAULT_BFLOAT16_CONSTEXPR biovault::bfloat16_t bf16(std::uint16_t{}, bool{});
-	BIOVAULT_BFLOAT16_CONSTEXPR std::uint16_t ui16{ get_raw_bits(bf16) };
+	constexpr biovault::bfloat16_t bf16(std::uint16_t{}, bool{});
+	constexpr std::uint16_t ui16{ get_raw_bits(bf16) };
 
 	static_assert(ui16 == std::uint16_t{}, "Round tripped raw zero bits should yield zero");
 	ASSERT_EQ(ui16, std::uint16_t{});
 
-	const auto uint16_max = std::numeric_limits<std::uint16_t>::max();
+	constexpr auto uint16_max = std::numeric_limits<std::uint16_t>::max();
 
 	for (std::uint16_t i = uint16_max; i > 0; --i)
 	{

--- a/biovault_bfloat16_test.cpp
+++ b/biovault_bfloat16_test.cpp
@@ -23,11 +23,10 @@
 
 // Standard library header files:
 #include <array>
-#include <cmath>    // For isnan.
+#include <cmath>    // For fpclassify.
 #include <cstring>
 #include <string>
 #include <limits>
-#include <vector>
 
 // References:
 //


### PR DESCRIPTION
The first commit aims to address issue #3 ("mixup with epsilon numbers?"), reported by Cédric Berger @ceedriic.

The other commits do some code cleanup and upgrade build systems.

Note that none of the commits of this pull request do any modification to the `biovault::bfloat_t` implementation ("biovault_bfloat16.h") itself. They are all about testing, and the CI system.