### PR TITLE
Add bfloat16_t::operator+=(a) overload for float argument type

### DIFF
--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -156,7 +156,12 @@ namespace biovault {
 			return (*this) = bfloat16_t{ f };
 		}
 
-		bfloat16_t &operator+=(const bfloat16_t a) {
+		bfloat16_t &operator+=(const float a) {
+			(*this) = bfloat16_t{ float{*this} + a };
+			return *this;
+		}
+
+		bfloat16_t& operator+=(const bfloat16_t a) {
 			(*this) = bfloat16_t{ float{*this} + float{a} };
 			return *this;
 		}

--- a/biovault_bfloat16_test.cpp
+++ b/biovault_bfloat16_test.cpp
@@ -658,3 +658,20 @@ GTEST_TEST(bfloat16, PlusCompoundAssignmentAddsRightToLeft)
 		}
 	}
 }
+
+
+#ifndef BIOVAULT_BFLOAT16_TEST_NO_PLUS_COMPOUND_ASSIGNMENT_FOR_FLOAT_ARGUMENT
+GTEST_TEST(bfloat16, PlusCompoundAssignmentAllowsAddingDenormal)
+{
+	const bfloat16_t initial_value{ float_limits::min() };
+	constexpr auto denorm = float_limits::min() / 2.0f;
+	auto test_value = initial_value;
+	
+	// The compound assignment to be tested, adding a float to a bfloat16.
+	test_value += denorm;
+
+	// Assert that adding the denormal has made the test value greater than before,
+	// even though a denormal is flushed to zero when directly assigned to a bfloat16. 
+	ASSERT_GT(float{ test_value }, float{ initial_value });
+}
+#endif


### PR DESCRIPTION
Will perform significantly faster than when doing `bf16 += bfloat16_t{f}`, for a bfloat16 `bf16`, and a 32-bit float argument `f`.

Might yield slightly more precise results. For example, for `bf16 += d`, when `d` is a denormal 32-bit float (as tested).