### PR TITLE
Remove redundant bfloat16_t::operator+=(bfloat16_t) overload

### DIFF
--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -161,11 +161,6 @@ namespace biovault {
 			return *this;
 		}
 
-		bfloat16_t& operator+=(const bfloat16_t a) {
-			(*this) = bfloat16_t{ float{*this} + float{a} };
-			return *this;
-		}
-
 		friend BIOVAULT_BFLOAT16_CONSTEXPR uint16_t get_raw_bits(const bfloat16_t&);
 	};
 


### PR DESCRIPTION
The member function `operator+=(bfloat16_t)` has become redundant when `operator+=(bfloat16_t)` was added, with pull request https://github.com/biovault/biovault_bfloat16/pull/14, "Add bfloat16_t::operator+=(a) overload for float argument type", 17 July 2020, commit 96596a49bcafe592526833fbfa108faa79764997

Note that adding a bfloat16 to another one is still fully supported, as a `bfloat16_t` argument converts implicitly to `float`.

This commit and the one of 17 July (96596a49bcafe592526833fbfa108faa79764997) together correspond with Intel oneDNN commit "common: bfloat16: replace operator+=(bfloat16_t) by operator+=(float)", 21 July 2020: https://github.com/oneapi-src/oneDNN/commit/d68271b7474f3a7e427d4637cef835592688be52