### PR TITLE
Suppress a warning about supporting implicit conversion to float

### DIFF
--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -140,6 +140,7 @@ namespace biovault {
 		}
 
 
+		// NOLINTNEXTLINE Allow implicit conversion to float, because it is lossless.
 		operator float() const {
 			// Implementation originally from:
 			// https://github.com/oneapi-src/oneDNN/blob/v1.5/src/cpu/bfloat16.cpp#L75-L76


### PR DESCRIPTION
Suppress a warning from Clang-Tidy (LLVM 10.0), which said:

> warning: 'operator float' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]

https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html#google-explicit-constructor