### PR TITLE
Fix CMake Warning CMP0048 not set, project() command manages VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Niels Dekker, LKEB, Leiden University Medical Center, 2020
 
-project(biovault_bfloat16)
-
 # At the moment of writing (July 2020), the Microsoft-hosted VM ubuntu-18.04
 # still runs CMake 3.17.0 on Azure Pipelines.
 cmake_minimum_required( VERSION 3.17.0 )
+
+project(biovault_bfloat16)
 
 message(STATUS "[${PROJECT_NAME}] CMAKE_VERSION = ${CMAKE_VERSION}")
 message(STATUS "[${PROJECT_NAME}] CMAKE_GENERATOR = ${CMAKE_GENERATOR}")


### PR DESCRIPTION
Placed `cmake_minimum_required` command before `project` command, to fix:

> CMake Warning (dev) at CMakeLists.txt:3 (project):
>   Policy CMP0048 is not set: project() command manages VERSION variables.
>   Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
>   command to set the policy and suppress this warning.
>
>   The following variable(s) would be set to empty:
>
>     CMAKE_PROJECT_VERSION
>     CMAKE_PROJECT_VERSION_MAJOR
>     CMAKE_PROJECT_VERSION_MINOR
>     CMAKE_PROJECT_VERSION_PATCH
> This warning is for project developers.  Use -Wno-dev to suppress it