### PR TITLE
Ensure exponent of std::pow is float, to fix VS2019 v16.8 warning C4244

### DIFF
--- a/biovault_bfloat16_test.cpp
+++ b/biovault_bfloat16_test.cpp
@@ -219,24 +219,24 @@ GTEST_TEST(bfloat16, EightBitWholeNumberRoundTripIsLossless)
 GTEST_TEST(bfloat16, PowerOfTwoRoundTripIsLossless)
 {
 	// For exponent = 128 down to one.
-	for (std::uint8_t exponent{ std::uint8_t{1u} << std::uint8_t{7u} }; exponent > 0; --exponent)
+	for (float exponent{ 1 << 7 }; exponent > 0; --exponent)
 	{
 		SCOPED_TRACE(std::string("exponent") + std::to_string(exponent));
-		assert_lossless_roundtrip(std::pow(2.0f, int{ exponent }));
+		assert_lossless_roundtrip(std::pow(2.0f, exponent));
 	}
 
-	// "The minimum positive normal value is 2 ^ −126..."
+	// "The minimum positive normal value is 2 ^ -126"
 	// https://en.wikipedia.org/wiki/Bfloat16_floating-point_format#Exponent_encoding
 
-	constexpr auto abs_exponent_of_minimum_positive = (std::uint8_t{ 1u } << std::uint8_t{ 7u }) - std::uint8_t{ 2 };
+	constexpr auto exponent_of_minimum_positive_normal = -126.0f;
 
-	ASSERT_EQ(std::pow(2.0f, -int{ abs_exponent_of_minimum_positive }), float_limits::min());
+	ASSERT_EQ(std::pow(2.0f, exponent_of_minimum_positive_normal), float_limits::min());
 
 	// For exponent = -126 up to minus one.
-	for (std::uint8_t abs_exponent{ abs_exponent_of_minimum_positive }; abs_exponent > 0; --abs_exponent)
+	for (auto exponent = exponent_of_minimum_positive_normal; exponent < 0; ++exponent)
 	{
-		SCOPED_TRACE(std::string("exponent -") + std::to_string(abs_exponent));
-		assert_lossless_roundtrip(std::pow(2.0f, -int{ abs_exponent }));
+		SCOPED_TRACE(std::string("exponent -") + std::to_string(exponent));
+		assert_lossless_roundtrip(std::pow(2.0f, exponent));
 	}
 }
 


### PR DESCRIPTION
It appears that with Visual C++ 2019 Version 16.8.0, expressions like `std::pow(2.0f, int{ exponent })` return a `double`, while with a previous Visual C++ version, it returned a `float`. This new behavior appears introduced with "Remove pow(floating, int) overloads", pull request https://github.com/microsoft/STL/pull/903  It caused the following warnings:

> biovault_bfloat16_test.cpp(225,37): error C2220: the following warning is treated as an error
> biovault_bfloat16_test.cpp(225,37): warning C4244: 'argument': conversion from 'double' to 'const float', possible loss of data
> biovault_bfloat16_test.cpp(239,37): warning C4244: 'argument': conversion from 'double' to 'const float', possible loss of data

This commit fixes the warnings by making sure that the second argument of `std::pow(2.0f, exponent)` calls is a `float`, instead of an integer.