### PR TITLE
Use is_standard_layout instead of is_pod for C++20

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.11.4)
+cmake_minimum_required(VERSION 3.17.0)
 
 project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -27,7 +27,7 @@
 #include <cmath>
 #include <cfloat>
 #include <cstring>
-#include <type_traits> // For enable_if, is_integral, and is_pod.
+#include <type_traits> // For enable_if, is_integral, is_trivially_copyable, and is_pod.
 
 
 // For a tagged version of the biovault_bfloat16 repository, having tag name
@@ -35,7 +35,7 @@
 // match that tag:
 #define BIOVAULT_BFLOAT16_MAJOR_VERSION 1
 #define BIOVAULT_BFLOAT16_MINOR_VERSION 0
-#define BIOVAULT_BFLOAT16_PATCH_VERSION 1
+#define BIOVAULT_BFLOAT16_PATCH_VERSION 2
 
 
 #ifdef _MSC_VER
@@ -75,10 +75,16 @@ namespace biovault {
 		template <typename T, typename U>
 		static T bit_cast(const U& u) {
 			static_assert(sizeof(T) == sizeof(U), "Bit-casting must preserve size.");
+#if __cplusplus >= 202002L
+    			// C++20 (and later) code
+			static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable.");
+			static_assert(std::is_trivially_copyable<U>::value, "U must be trivially copyable.");
+#else
 			// Use std::is_pod as older GNU versions do not support
 			// std::is_trivially_copyable.
 			static_assert(std::is_pod<T>::value, "T must be trivially copyable.");
 			static_assert(std::is_pod<U>::value, "U must be trivially copyable.");
+#endif
 
 			T t;
 			std::memcpy(&t, &u, sizeof(U));


### PR DESCRIPTION
[`is_pod`](https://en.cppreference.com/w/cpp/types/is_pod) is deprecated in C++20 and produces a warning:

> biovault_bfloat16.h(80,23): warning C4996: 'std::is_pod<std::array<biovault::bfloat16_t::uint16_t,2>>': warning STL4025: std::is_pod and std::is_pod_v are deprecated in C++20. The std::is_trivially_copyable and/or std::is_standard_layout traits likely suit your use case. You can define _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.

As already mentioned in a comment in the code, I suggest using `is_trivially_copyable` instead when using c++20.

Drive-by changes:
- [googletest](https://github.com/google/googletest) default branch is now main, not master anymore