### PR TITLE
Fix Azure Pipelines CI failures by upgrading ubuntu and macOS VM's

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,9 @@ jobs:
       .\build\Release\biovault_bfloat16_test.exe
     displayName: $(Agent.JobName) run
 
-- job: Ubuntu1804_GCC_7_4_0
+- job: Ubuntu
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - script: |
       mkdir build
@@ -30,9 +30,9 @@ jobs:
       ./build/biovault_bfloat16_test
     displayName: $(Agent.JobName) run
    
-- job: macOS1015_AppleClang
+- job: MacOS
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-13'
   steps:
   - script: |
       mkdir build


### PR DESCRIPTION
Aims to fix the errors at https://dev.azure.com/dekkerware/dekkerware/_build/results?buildId=613&view=results saying:

> No config name or imagelabel provided in request
> The remote provider was unable to process the request.